### PR TITLE
feat: Liveness, Readiness, Startup probe, progressDeadlineSeconds, Rolling Update

### DIFF
--- a/charts/helicone-ai-gateway/templates/deployment.yaml
+++ b/charts/helicone-ai-gateway/templates/deployment.yaml
@@ -6,7 +6,19 @@ metadata:
   labels:
     {{- include "helicone.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.helicone.aiGateway.replicaCount }}
+  {{- if .Values.helicone.aiGateway.strategy }}
+  strategy:
+    type: {{ .Values.helicone.aiGateway.strategy.type }}
+    {{- if eq .Values.helicone.aiGateway.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.helicone.aiGateway.strategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.helicone.aiGateway.strategy.rollingUpdate.maxSurge }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.helicone.aiGateway.progressDeadlineSeconds }}
+  progressDeadlineSeconds: {{ .Values.helicone.aiGateway.progressDeadlineSeconds }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "helicone.ai-gateway.selectorLabels" . | nindent 6 }}
@@ -29,6 +41,52 @@ spec:
             - name: config
               mountPath: /app/config
               readOnly: true
+          {{- end }}
+          {{- if .Values.helicone.aiGateway.resources }}
+          resources:
+            {{- toYaml .Values.helicone.aiGateway.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.helicone.aiGateway.livenessProbe.enabled }}
+          livenessProbe:
+            {{- if .Values.helicone.aiGateway.livenessProbe.httpGet }}
+            httpGet:
+              path: {{ .Values.helicone.aiGateway.livenessProbe.httpGet.path }}
+              port: {{ .Values.helicone.aiGateway.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.helicone.aiGateway.livenessProbe.httpGet.scheme }}
+            {{- end }}
+            initialDelaySeconds: {{ .Values.helicone.aiGateway.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.helicone.aiGateway.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.helicone.aiGateway.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.helicone.aiGateway.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.helicone.aiGateway.livenessProbe.successThreshold }}
+          {{- end }}
+          {{- if .Values.helicone.aiGateway.readinessProbe.enabled }}
+          readinessProbe:
+            {{- if .Values.helicone.aiGateway.readinessProbe.httpGet }}
+            httpGet:
+              path: {{ .Values.helicone.aiGateway.readinessProbe.httpGet.path }}
+              port: {{ .Values.helicone.aiGateway.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.helicone.aiGateway.readinessProbe.httpGet.scheme }}
+            {{- end }}
+            initialDelaySeconds: {{ .Values.helicone.aiGateway.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.helicone.aiGateway.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.helicone.aiGateway.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.helicone.aiGateway.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.helicone.aiGateway.readinessProbe.successThreshold }}
+          {{- end }}
+          {{- if .Values.helicone.aiGateway.startupProbe.enabled }}
+          startupProbe:
+            {{- if .Values.helicone.aiGateway.startupProbe.httpGet }}
+            httpGet:
+              path: {{ .Values.helicone.aiGateway.startupProbe.httpGet.path }}
+              port: {{ .Values.helicone.aiGateway.startupProbe.httpGet.port }}
+              scheme: {{ .Values.helicone.aiGateway.startupProbe.httpGet.scheme }}
+            {{- end }}
+            initialDelaySeconds: {{ .Values.helicone.aiGateway.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.helicone.aiGateway.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.helicone.aiGateway.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.helicone.aiGateway.startupProbe.failureThreshold }}
+            successThreshold: {{ .Values.helicone.aiGateway.startupProbe.successThreshold }}
           {{- end }}
           env:
             # TODO Move to _helpers.tpl

--- a/charts/helicone-ai-gateway/values.example.yaml
+++ b/charts/helicone-ai-gateway/values.example.yaml
@@ -6,6 +6,17 @@ helicone:
       pullPolicy: IfNotPresent
       tag: "main"
     replicaCount: 1
+    
+    # Rolling Update Deployment Strategy
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
+    
+    # Progress deadline for deployments (in seconds)
+    progressDeadlineSeconds: 600
+    
     service:
       annotations: {}
       type: ClusterIP
@@ -27,6 +38,44 @@ helicone:
       limits:
         cpu: 250m
         memory: 512Mi
+    
+    # Health Probes Configuration
+    livenessProbe:
+      enabled: true
+      httpGet:
+        path: /health
+        port: http
+        scheme: HTTP
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      timeoutSeconds: 5
+      failureThreshold: 3
+      successThreshold: 1
+    
+    readinessProbe:
+      enabled: true
+      httpGet:
+        path: /health
+        port: http
+        scheme: HTTP
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 3
+      failureThreshold: 3
+      successThreshold: 1
+    
+    startupProbe:
+      enabled: true
+      httpGet:
+        path: /health
+        port: http
+        scheme: HTTP
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 30
+      successThreshold: 1
+    
     extraEnvVars:
       - name: AI_GATEWAY__SERVER__ADDRESS
         value: "0.0.0.0"


### PR DESCRIPTION
This pull request enhances the Helm chart for the Helicone AI Gateway by introducing configurable deployment strategies, resource limits, and health probes. These changes improve the flexibility, reliability, and observability of the deployment.

### Deployment Configuration Enhancements:

* Introduced support for configurable replica counts and rolling update deployment strategies, including `maxUnavailable` and `maxSurge` parameters, allowing for smoother updates. (`charts/helicone-ai-gateway/templates/deployment.yaml`, [[1]](diffhunk://#diff-25bdefb86a5dfe64e84398e851bbd5d54098bf82dd393277b9a3b018e405f75fL9-R21); `charts/helicone-ai-gateway/values.example.yaml`, [[2]](diffhunk://#diff-cdc7a783fd1a3de4f42e14976044f4de84c3f13357621bd3905528281bb7c99aR9-R19)

* Added the ability to configure `progressDeadlineSeconds`, providing control over deployment timeout behavior. (`charts/helicone-ai-gateway/templates/deployment.yaml`, [[1]](diffhunk://#diff-25bdefb86a5dfe64e84398e851bbd5d54098bf82dd393277b9a3b018e405f75fL9-R21); `charts/helicone-ai-gateway/values.example.yaml`, [[2]](diffhunk://#diff-cdc7a783fd1a3de4f42e14976044f4de84c3f13357621bd3905528281bb7c99aR9-R19)

### Resource Management:

* Enabled configuration of resource requests and limits for the deployment, ensuring better resource allocation and predictability. (`charts/helicone-ai-gateway/templates/deployment.yaml`, [charts/helicone-ai-gateway/templates/deployment.yamlR45-R90](diffhunk://#diff-25bdefb86a5dfe64e84398e851bbd5d54098bf82dd393277b9a3b018e405f75fR45-R90))

### Health Probes:

* Added support for `livenessProbe`, `readinessProbe`, and `startupProbe`, allowing for better monitoring and management of the application's health and startup states. (`charts/helicone-ai-gateway/templates/deployment.yaml`, [[1]](diffhunk://#diff-25bdefb86a5dfe64e84398e851bbd5d54098bf82dd393277b9a3b018e405f75fR45-R90); `charts/helicone-ai-gateway/values.example.yaml`, [[2]](diffhunk://#diff-cdc7a783fd1a3de4f42e14976044f4de84c3f13357621bd3905528281bb7c99aR41-R78)