### PR TITLE
feat: S3 service account setup for SIA

### DIFF
--- a/charts/helicone-core/templates/_helpers.tpl
+++ b/charts/helicone-core/templates/_helpers.tpl
@@ -142,6 +142,7 @@ ClickHouse host for Jawn application (URL format for Node.js client)
 */}}
 # TODO This conditional logic will incur tech debt which needs to be refactored.
 {{- define "helicone.env.s3AccessKey" -}}
+{{- if not (and .Values.helicone.s3 .Values.helicone.s3.serviceAccount .Values.helicone.s3.serviceAccount.enabled) }}
 - name: S3_ACCESS_KEY
 {{- if .Values.helicone.minio.enabled }}
   valueFrom:
@@ -155,8 +156,10 @@ ClickHouse host for Jawn application (URL format for Node.js client)
       key: {{ .Values.helicone.config.s3AccessKeyKey | default "access_key" | quote }}
 {{- end }}
 {{- end }}
+{{- end }}
 
 {{- define "helicone.env.s3SecretKey" -}}
+{{- if not (and .Values.helicone.s3 .Values.helicone.s3.serviceAccount .Values.helicone.s3.serviceAccount.enabled) }}
 - name: S3_SECRET_KEY
 {{- if .Values.helicone.minio.enabled }}
   valueFrom:
@@ -170,11 +173,14 @@ ClickHouse host for Jawn application (URL format for Node.js client)
       key: {{ .Values.helicone.config.s3SecretKeyKey | default "secret_key" | quote }}
 {{- end }}
 {{- end }}
+{{- end }}
 
 {{- define "helicone.env.s3Endpoint" -}}
 - name: S3_ENDPOINT
 {{- if .Values.helicone.minio.enabled }}
   value: {{ .Values.helicone.config.s3Endpoint | default (printf "http://%s:%s" (include "minio.name" .) (.Values.helicone.minio.service.port | toString)) | quote }}
+{{- else if and .Values.helicone.s3 .Values.helicone.s3.serviceAccount .Values.helicone.s3.serviceAccount.enabled }}
+  value: {{ .Values.helicone.s3.endpoint | default "https://s3.amazonaws.com" | quote }}
 {{- else }}
   valueFrom:
     secretKeyRef:
@@ -187,6 +193,8 @@ ClickHouse host for Jawn application (URL format for Node.js client)
 - name: S3_BUCKET_NAME
 {{- if .Values.helicone.minio.enabled }}
   value: {{ .Values.helicone.config.s3BucketName | default (index .Values.helicone.minio.setup.buckets 0) | quote }}
+{{- else if and .Values.helicone.s3 .Values.helicone.s3.serviceAccount .Values.helicone.s3.serviceAccount.enabled }}
+  value: {{ .Values.helicone.s3.bucketName | default "helm-request-response-storage" | quote }}
 {{- else }}
   valueFrom:
     secretKeyRef:

--- a/charts/helicone-core/templates/jawn/deployment.yaml
+++ b/charts/helicone-core/templates/jawn/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       labels:
         {{- include "helicone.jawn.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if and .Values.helicone.s3 .Values.helicone.s3.serviceAccount .Values.helicone.s3.serviceAccount.enabled }}
+      serviceAccountName: {{ include "jawn.name" . }}
+      {{- end }}
       containers:
         - name: {{ include "jawn.name" $ }}
           image: "{{ .Values.helicone.jawn.image.repository }}:{{ .Values.helicone.jawn.image.tag }}"

--- a/charts/helicone-core/templates/jawn/serviceaccount.yaml
+++ b/charts/helicone-core/templates/jawn/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.helicone.s3 .Values.helicone.s3.serviceAccount .Values.helicone.s3.serviceAccount.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "jawn.name" . }}
+  labels:
+    {{- include "helicone.labels" . | nindent 4 }}
+  annotations:
+    {{- include "helicone.annotations" . | nindent 4 }}
+    eks.amazonaws.com/role-arn: {{ .Values.helicone.s3.serviceAccount.roleArn | quote }}
+{{- end }} 

--- a/charts/helicone-core/templates/web/deployment.yaml
+++ b/charts/helicone-core/templates/web/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         {{- include "helicone.web.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if and .Values.helicone.web.cloudSqlProxy.enabled .Values.helicone.web.cloudSqlProxy.useWorkloadIdentity }}
+      {{- if or (and .Values.helicone.web.cloudSqlProxy.enabled .Values.helicone.web.cloudSqlProxy.useWorkloadIdentity) (and .Values.helicone.s3 .Values.helicone.s3.serviceAccount .Values.helicone.s3.serviceAccount.enabled) }}
       serviceAccountName: {{ include "web.name" . }}
       {{- end }}
       initContainers:

--- a/charts/helicone-core/templates/web/serviceaccount.yaml
+++ b/charts/helicone-core/templates/web/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.helicone.web.enabled .Values.helicone.web.cloudSqlProxy.enabled .Values.helicone.web.cloudSqlProxy.useWorkloadIdentity }}
+{{- if or (and .Values.helicone.web.enabled .Values.helicone.web.cloudSqlProxy.enabled .Values.helicone.web.cloudSqlProxy.useWorkloadIdentity) (and .Values.helicone.s3 .Values.helicone.s3.serviceAccount .Values.helicone.s3.serviceAccount.enabled) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,7 +7,10 @@ metadata:
     {{- include "helicone.labels" . | nindent 4 }}
   annotations:
     {{- include "helicone.annotations" . | nindent 4 }}
-    {{- if .Values.helicone.web.cloudSqlProxy.workloadIdentityAnnotation }}
+    {{- if and .Values.helicone.web.cloudSqlProxy.enabled .Values.helicone.web.cloudSqlProxy.useWorkloadIdentity .Values.helicone.web.cloudSqlProxy.workloadIdentityAnnotation }}
     iam.gke.io/gcp-service-account: {{ .Values.helicone.web.cloudSqlProxy.workloadIdentityAnnotation }}
+    {{- end }}
+    {{- if and .Values.helicone.s3 .Values.helicone.s3.serviceAccount .Values.helicone.s3.serviceAccount.enabled }}
+    eks.amazonaws.com/role-arn: {{ .Values.helicone.s3.serviceAccount.roleArn | quote }}
     {{- end }}
 {{- end }} 

--- a/charts/helicone-core/values.yaml
+++ b/charts/helicone-core/values.yaml
@@ -384,6 +384,21 @@ mailhog:
     googleProjectNumber: "GOOGLE_PROJECT_NUMBER"
     nodeEnv: "development"
 
+  # S3 Service Account Configuration (IRSA)
+  # Enable this to use IAM roles for service accounts instead of access keys
+  s3:
+    serviceAccount:
+      # Set to true to enable service account-based S3 access
+      enabled: false
+      # IAM role ARN that the service accounts will assume
+      # This should be the output from the S3 terraform module
+      # Example: "arn:aws:iam::123456789012:role/helm-request-response-storage-service-account-role"
+      roleArn: ""
+    # S3 configuration when using service accounts
+    bucketName: "helm-request-response-storage"
+    # S3 endpoint (leave default for AWS S3)
+    endpoint: "https://s3.amazonaws.com"
+
 #################################################################################
 # External Secrets Configuration
 #################################################################################

--- a/terraform/s3/README.md
+++ b/terraform/s3/README.md
@@ -12,6 +12,7 @@ This Terraform configuration creates an S3 bucket named `helm-request-response-s
 - **Public Access**: Blocked (secure by default)
 - **CORS**: Configured to allow GET requests from `https://heliconetest.com`
 - **Tags**: Environment and purpose tags included
+- **Service Account Access**: Optional IAM roles for service accounts (IRSA) support
 
 ## Usage
 
@@ -57,11 +58,22 @@ terraform apply -var="bucket_name=my-custom-bucket" -var="environment=staging"
 
 ### Available Variables
 
+#### Basic Configuration
+
 - `bucket_name`: Name of the S3 bucket (default: "helm-request-response-storage")
 - `region`: AWS region (default: "us-west-2")
 - `environment`: Environment tag (default: "production")
 - `enable_versioning`: Enable bucket versioning (default: true)
 - `tags`: Additional tags as a map
+
+#### Service Account Access (IRSA)
+
+- `enable_service_account_access`: Enable IAM roles for service accounts (default: false)
+- `eks_oidc_provider`: EKS OIDC provider URL without https:// (required if IRSA enabled)
+- `kubernetes_namespace`: Kubernetes namespace for service accounts (default: "helicone")
+
+#### CORS Configuration
+
 - `cors_allowed_origins`: List of allowed origins for CORS (default: ["https://heliconetest.com"])
 - `cors_allowed_methods`: List of allowed HTTP methods for CORS (default: ["GET"])
 - `cors_allowed_headers`: List of allowed headers for CORS (default: ["*"])
@@ -77,6 +89,7 @@ After deployment, the following outputs will be available:
 - `bucket_domain_name`: The domain name of the bucket
 - `bucket_regional_domain_name`: The regional domain name
 - `bucket_region`: The region where the bucket is deployed
+- `s3_service_account_role_arn`: ARN of the IAM role for service account access (only when `enable_service_account_access` is true)
 
 ## Security
 

--- a/terraform/s3/outputs.tf
+++ b/terraform/s3/outputs.tf
@@ -21,4 +21,9 @@ output "bucket_regional_domain_name" {
 output "bucket_region" {
   description = "Region where the S3 bucket is deployed"
   value       = aws_s3_bucket.helm_request_response_storage.region
+}
+
+output "s3_service_account_role_arn" {
+  description = "ARN of the IAM role for service account access to S3"
+  value       = var.enable_service_account_access ? aws_iam_role.s3_service_account[0].arn : null
 } 

--- a/terraform/s3/terraform.tfvars.example
+++ b/terraform/s3/terraform.tfvars.example
@@ -1,1 +1,33 @@
-cors_allowed_origins = ["https://heliconetest.com", "https://filevine.helicone-test.com", "https://filevine.helicone.ai", "https://helicone.ai"]
+# Example Terraform variables for S3 bucket
+# Copy this file to terraform.tfvars and update with your actual values
+
+# S3 Configuration
+bucket_name = "helm-request-response-storage"
+region      = "us-west-2"
+environment = "production"
+enable_versioning = true
+
+# Service Account Access (IRSA) Configuration
+# Set to true to enable service account-based access instead of access keys
+enable_service_account_access = true
+
+# EKS OIDC provider URL (without https://)
+# Get this from: aws eks describe-cluster --name YOUR_CLUSTER_NAME --query "cluster.identity.oidc.issuer" --output text | sed 's|https://||'
+eks_oidc_provider = "oidc.eks.us-west-2.amazonaws.com/id/YOUR_CLUSTER_OIDC_ID"
+
+# Kubernetes namespace where helicone workloads run
+kubernetes_namespace = "helicone"
+
+# CORS Configuration
+cors_allowed_origins = ["https://heliconetest.com"]
+cors_allowed_methods = ["GET"]
+cors_allowed_headers = ["*"]
+cors_expose_headers = ["ETag"]
+cors_max_age_seconds = 3000
+
+# Tags
+tags = {
+  Environment = "production"
+  Project     = "helicone"
+  ManagedBy   = "terraform"
+}

--- a/terraform/s3/variables.tf
+++ b/terraform/s3/variables.tf
@@ -56,4 +56,23 @@ variable "cors_max_age_seconds" {
   description = "Maximum age in seconds for CORS preflight requests"
   type        = number
   default     = 3000
+}
+
+# Service Account Access Configuration
+variable "enable_service_account_access" {
+  description = "Enable IAM roles for service accounts (IRSA) for S3 access"
+  type        = bool
+  default     = false
+}
+
+variable "eks_oidc_provider" {
+  description = "EKS OIDC provider URL (without https://)"
+  type        = string
+  default     = ""
+}
+
+variable "kubernetes_namespace" {
+  description = "Kubernetes namespace where the service accounts will be created"
+  type        = string
+  default     = "helicone"
 } 


### PR DESCRIPTION
This pull request introduces support for accessing S3 buckets using IAM roles for service accounts (IRSA) in Kubernetes, alongside updates to documentation, Helm charts, and Terraform configurations. The changes aim to enhance security by providing an alternative to access keys and streamline S3 access management for Kubernetes workloads.

### Key Changes:

#### IRSA Support for S3 Access:
* **Terraform Configuration**: Added resources for creating IAM roles and policies to enable service account-based S3 access using OIDC providers. This includes trust policies, role attachments, and conditional resource creation based on the `enable_service_account_access` variable (`terraform/s3/main.tf`, `terraform/s3/variables.tf`, `terraform/s3/outputs.tf`). [[1]](diffhunk://#diff-64a2f1e72b85957b46a183d52835b8ffab9ccdbcbbc96e26bf4042e58ea185bdR70-R160) [[2]](diffhunk://#diff-20aa87a03f411109e66315551720f74d4597aa4290b3182ae3b0d3514b620335R60-R78) [[3]](diffhunk://#diff-9889a01c917c582c33bf99f3478b8d582504819cbfe0f35de14d199de64d0d81R25-R29)
* **Helm Chart Updates**: Modified templates to conditionally configure service accounts and environment variables when IRSA is enabled. This includes setting the `serviceAccountName` and adding annotations for the IAM role ARN (`charts/helicone-core/templates/_helpers.tpl`, `charts/helicone-core/templates/jawn/deployment.yaml`, `charts/helicone-core/templates/web/deployment.yaml`). [[1]](diffhunk://#diff-0f9ea567ce05295b2c4e480a5790a955ec55392cb4caa5df6e99a79df35bb326R145) [[2]](diffhunk://#diff-0f9ea567ce05295b2c4e480a5790a955ec55392cb4caa5df6e99a79df35bb326R159-R162) [[3]](diffhunk://#diff-0f9ea567ce05295b2c4e480a5790a955ec55392cb4caa5df6e99a79df35bb326R176-R183) [[4]](diffhunk://#diff-ab02e49b496f8782e017922728a6c0217b8579a65c6c3ac5497969beab53c7bdR20-R22) [[5]](diffhunk://#diff-34d8305fa71b48de4bb447ab42180106976601e63735f0ab6b3dd06ccd20c5d5L20-R20)

#### Documentation Enhancements:
* **README Updates**: Added detailed instructions for configuring IRSA, including Terraform and Helm steps. This includes enabling service account access, setting up OIDC providers, and configuring Helm values (`README.md`, `terraform/s3/README.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L182-R227) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R238-R239) [[3]](diffhunk://#diff-72ce0a68d25c354df62e7758cfda485d312d50a8c8099f24263c686b268293b6R15) [[4]](diffhunk://#diff-72ce0a68d25c354df62e7758cfda485d312d50a8c8099f24263c686b268293b6R61-R76) [[5]](diffhunk://#diff-72ce0a68d25c354df62e7758cfda485d312d50a8c8099f24263c686b268293b6R92)

#### Helm Chart Values:
* **New Configuration Options**: Introduced `helicone.s3.serviceAccount` in `values.yaml` to toggle IRSA support and specify the IAM role ARN, bucket name, and endpoint (`charts/helicone-core/values.yaml`).

#### Example and Default Configurations:
* **Terraform Example Variables**: Provided an updated example `terraform.tfvars` file to demonstrate IRSA setup, including EKS OIDC provider and Kubernetes namespace configuration (`terraform/s3/terraform.tfvars.example`).

#### Miscellaneous:
* **CORS Policy Outputs**: Updated Terraform outputs to include the IAM role ARN when IRSA is enabled (`terraform/s3/outputs.tf`).

These changes improve security and flexibility for S3 access in Kubernetes environments while providing clear guidance for setup and configuration.