### PR TITLE
feat: updated service account details

### DIFF
--- a/charts/helicone-core/values.yaml
+++ b/charts/helicone-core/values.yaml
@@ -5,6 +5,20 @@
 ################################################################################
 
 helicone:
+  # S3 configuration for service account-based access
+  s3:
+    # Set to true to use service accounts with IAM roles instead of access keys
+    serviceAccount:
+      enabled: true
+      # IAM role ARN for the service account to assume (will be updated after terraform apply)
+      roleArn: "arn:aws:iam::849596434884:role/helm-request-response-storage-service-account-role"
+      # AWS region for S3 service
+      region: "us-west-2"
+    # S3 bucket name (used when serviceAccount.enabled is true)
+    bucketName: "helm-request-response-storage"
+    # S3 endpoint (defaults to AWS S3 when using service accounts)
+    endpoint: "https://s3.us-west-2.amazonaws.com"
+
   web:
     enabled: true
     image:
@@ -251,7 +265,7 @@ helicone:
 
   # Note: If enabled is set to false, then S3 is used instead of MinIO
   minio:
-    enabled: true
+    enabled: false
     image:
       repository: minio/minio
       pullPolicy: IfNotPresent
@@ -330,21 +344,11 @@ helicone:
           percentPolicy: 100
           periodSeconds: 15
 
-mailhog:
-  enabled: true
-  image:
-    repository: mailhog/mailhog
-    tag: latest
-    pullPolicy: IfNotPresent
-  resources:
-    requests:
-      memory: "128Mi"
-      cpu: "100m"
-    limits:
-      memory: "256Mi"
-      cpu: "200m"
-
+  # Application configuration
   config:
+    # External database configuration (not needed when cloudnativepg.enabled=true)
+    dbPort: "5432" # Default port for PostgreSQL
+    heliconePassword: "changeme-in-production" # Password for helicone app user
     vercelEnv: "development"
     clickhouseHost: "https://ucewi94kth.us-west-2.aws.clickhouse.cloud" # TODO Not doing DRY between the two configs (above configuration as well)
     clickhousePort: "8443"
@@ -384,20 +388,19 @@ mailhog:
     googleProjectNumber: "GOOGLE_PROJECT_NUMBER"
     nodeEnv: "development"
 
-  # S3 Service Account Configuration (IRSA)
-  # Enable this to use IAM roles for service accounts instead of access keys
-  s3:
-    serviceAccount:
-      # Set to true to enable service account-based S3 access
-      enabled: false
-      # IAM role ARN that the service accounts will assume
-      # This should be the output from the S3 terraform module
-      # Example: "arn:aws:iam::123456789012:role/helm-request-response-storage-service-account-role"
-      roleArn: ""
-    # S3 configuration when using service accounts
-    bucketName: "helm-request-response-storage"
-    # S3 endpoint (leave default for AWS S3)
-    endpoint: "https://s3.amazonaws.com"
+mailhog:
+  enabled: true
+  image:
+    repository: mailhog/mailhog
+    tag: latest
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "100m"
+    limits:
+      memory: "256Mi"
+      cpu: "200m"
 
 #################################################################################
 # External Secrets Configuration

--- a/terraform/s3/main.tf
+++ b/terraform/s3/main.tf
@@ -99,8 +99,8 @@ data "aws_iam_policy_document" "s3_service_account_trust" {
       test     = "StringEquals"
       variable = "${var.eks_oidc_provider}:sub"
       values   = [
-        "system:serviceaccount:${var.kubernetes_namespace}:helicone-web",
-        "system:serviceaccount:${var.kubernetes_namespace}:helicone-jawn"
+        "system:serviceaccount:${var.kubernetes_namespace}:helicone-core-web",
+        "system:serviceaccount:${var.kubernetes_namespace}:helicone-core-jawn"
       ]
     }
 


### PR DESCRIPTION
This pull request updates the configuration for the Helicone Core chart and its associated Terraform module to enhance S3 service account integration and streamline resource management. The changes include enabling service account-based S3 access, disabling MinIO, reorganizing Mailhog configuration, and updating IAM policy references.

### S3 Service Account Integration:
* Added configuration for S3 service account-based access in `charts/helicone-core/values.yaml`, including IAM role ARN, region, bucket name, and endpoint. (`[charts/helicone-core/values.yamlR8-R21](diffhunk://#diff-e7ce1218ba46adbe0acf62e04f378656517abcacdfbb91268de70ea5b739c9d7R8-R21)`)
* Removed legacy S3 service account configuration in favor of the new structure. (`[charts/helicone-core/values.yamlL387-R403](diffhunk://#diff-e7ce1218ba46adbe0acf62e04f378656517abcacdfbb91268de70ea5b739c9d7L387-R403)`)

### Resource Management Updates:
* Disabled MinIO by default, indicating a shift to S3 for storage. (`[charts/helicone-core/values.yamlL254-R268](diffhunk://#diff-e7ce1218ba46adbe0acf62e04f378656517abcacdfbb91268de70ea5b739c9d7L254-R268)`)
* Reorganized Mailhog configuration, moving it to a different section in `charts/helicone-core/values.yaml`. (`[[1]](diffhunk://#diff-e7ce1218ba46adbe0acf62e04f378656517abcacdfbb91268de70ea5b739c9d7L333-R351)`, `[[2]](diffhunk://#diff-e7ce1218ba46adbe0acf62e04f378656517abcacdfbb91268de70ea5b739c9d7L387-R403)`)

### Terraform Updates:
* Updated IAM policy references in `terraform/s3/main.tf` to reflect new service account naming conventions (`helicone-core-web` and `helicone-core-jawn`). (`[terraform/s3/main.tfL102-R103](diffhunk://#diff-64a2f1e72b85957b46a183d52835b8ffab9ccdbcbbc96e26bf4042e58ea185bdL102-R103)`)