### PR TITLE
fix: Fix elb not connecting to pod

### DIFF
--- a/charts/helicone-infrastructure/values.yaml
+++ b/charts/helicone-infrastructure/values.yaml
@@ -117,6 +117,7 @@ nginxIngressController:
       type: LoadBalancer # Back to LoadBalancer - Pod Identity should fix permissions
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-type: nlb
+        service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing # Make NLB internet-facing
         service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
         # Pod Identity handles authentication automatically - no more manual annotations needed
       ports:

--- a/charts/helicone-infrastructure/values.yaml
+++ b/charts/helicone-infrastructure/values.yaml
@@ -112,12 +112,13 @@ nginxIngressController:
         cpu: 500m
         memory: 512Mi
 
-    # Service configuration
+    # Service configuration - Using Pod Identity with proper permissions
     service:
-      type: LoadBalancer
+      type: LoadBalancer # Back to LoadBalancer - Pod Identity should fix permissions
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-type: nlb
         service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+        # Pod Identity handles authentication automatically - no more manual annotations needed
       ports:
         http: 80
         https: 443
@@ -126,7 +127,7 @@ nginxIngressController:
     ingressClass:
       name: nginx
       enabled: true
-      default: true
+      default: true # Keep nginx as default for existing ingresses
       controllerValue: "k8s.io/ingress-nginx"
 
     # RBAC configuration for cross-namespace access
@@ -134,10 +135,10 @@ nginxIngressController:
       create: true
       scope: true # Cluster-wide scope for all namespaces
 
-    # Service account
+    # Service account - IMPORTANT: Must match Terraform Pod Identity association
     serviceAccount:
       create: true
-      name: nginx-ingress-controller
+      name: nginx-ingress-controller # This matches the Pod Identity association
 
 # Prometheus configuration
 prometheus:

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -184,6 +184,79 @@ resource "aws_iam_role_policy_attachment" "eks_ebs_csi_driver_policy" {
   role       = aws_iam_role.eks_node_role.name
 }
 
+# Additional policy for EKS nodes to create LoadBalancers
+resource "aws_iam_policy" "eks_node_loadbalancer_policy" {
+  name        = "${var.cluster_name}-node-loadbalancer-policy"
+  description = "IAM policy for EKS nodes to create LoadBalancers"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:DescribeLoadBalancers",
+          "elasticloadbalancing:DescribeLoadBalancerAttributes",
+          "elasticloadbalancing:DescribeListeners",
+          "elasticloadbalancing:DescribeRules",
+          "elasticloadbalancing:DescribeTargetGroups",
+          "elasticloadbalancing:DescribeTargetGroupAttributes",
+          "elasticloadbalancing:DescribeTargetHealth",
+          "elasticloadbalancing:DescribeTags",
+          "elasticloadbalancing:CreateLoadBalancer",
+          "elasticloadbalancing:CreateTargetGroup",
+          "elasticloadbalancing:CreateListener",
+          "elasticloadbalancing:CreateRule",
+          "elasticloadbalancing:DeleteLoadBalancer",
+          "elasticloadbalancing:DeleteTargetGroup",
+          "elasticloadbalancing:DeleteListener",
+          "elasticloadbalancing:DeleteRule",
+          "elasticloadbalancing:ModifyLoadBalancerAttributes",
+          "elasticloadbalancing:ModifyTargetGroup",
+          "elasticloadbalancing:ModifyTargetGroupAttributes",
+          "elasticloadbalancing:ModifyRule",
+          "elasticloadbalancing:RegisterTargets",
+          "elasticloadbalancing:DeregisterTargets",
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:RemoveTags",
+          "elasticloadbalancing:SetSubnets",
+          "elasticloadbalancing:SetSecurityGroups"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeVpcs",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeInstances",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeAccountAttributes",
+          "ec2:DescribeAddresses",
+          "ec2:DescribeInternetGateways",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeTags",
+          "ec2:CreateSecurityGroup",
+          "ec2:CreateTags",
+          "ec2:DeleteTags",
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:RevokeSecurityGroupIngress",
+          "ec2:DeleteSecurityGroup"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "eks_node_loadbalancer_policy" {
+  policy_arn = aws_iam_policy.eks_node_loadbalancer_policy.arn
+  role       = aws_iam_role.eks_node_role.name
+}
+
 # EKS Node Group
 resource "aws_eks_node_group" "eks_nodes" {
   cluster_name    = aws_eks_cluster.eks_cluster.name

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -233,4 +233,37 @@ variable "alb_controller_namespace" {
   default     = "default"
 }
 
- 
+# External Secrets CSI Driver Configuration
+variable "enable_external_secrets_csi_driver" {
+  description = "Enable AWS Secrets Manager CSI driver"
+  type        = bool
+  default     = false
+}
+
+variable "external_secrets_csi_driver_policy_arn" {
+  description = "Custom IAM policy ARN for External Secrets CSI driver (leave empty to create)"
+  type        = string
+  default     = ""
+}
+
+variable "external_secrets_csi_driver_version" {
+  description = "External Secrets CSI driver version"
+  type        = string
+  default     = "v1.0.0-eksbuild.1"
+}
+
+#################################################################################
+# NGINX Ingress Controller Configuration
+#################################################################################
+
+variable "enable_nginx_ingress_controller" {
+  description = "Enable NGINX Ingress Controller with Pod Identity"
+  type        = bool
+  default     = true
+}
+
+variable "nginx_ingress_controller_namespace" {
+  description = "Namespace for NGINX Ingress Controller"
+  type        = string
+  default     = "helicone-infrastructure"
+}

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -233,12 +233,6 @@ variable "alb_controller_namespace" {
   default     = "default"
 }
 
-variable "external_secrets_csi_driver_version" {
-  description = "External Secrets CSI driver version"
-  type        = string
-  default     = "v1.0.0-eksbuild.1"
-}
-
 #################################################################################
 # NGINX Ingress Controller Configuration
 #################################################################################

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -233,19 +233,6 @@ variable "alb_controller_namespace" {
   default     = "default"
 }
 
-# External Secrets CSI Driver Configuration
-variable "enable_external_secrets_csi_driver" {
-  description = "Enable AWS Secrets Manager CSI driver"
-  type        = bool
-  default     = false
-}
-
-variable "external_secrets_csi_driver_policy_arn" {
-  description = "Custom IAM policy ARN for External Secrets CSI driver (leave empty to create)"
-  type        = string
-  default     = ""
-}
-
 variable "external_secrets_csi_driver_version" {
   description = "External Secrets CSI driver version"
   type        = string


### PR DESCRIPTION
This pull request focuses on enabling and configuring Pod Identity for the NGINX Ingress Controller and enhancing IAM policies for better resource management in an EKS environment. Key changes include updates to the Helm chart values, Terraform configurations for IAM roles and policies, and the introduction of new variables for flexibility.

### NGINX Ingress Controller Enhancements:
* Updated `charts/helicone-infrastructure/values.yaml` to configure the NGINX Ingress Controller for Pod Identity, including changes to the service type, annotations, and service account to align with the new Pod Identity setup. [[1]](diffhunk://#diff-76c5f5c1d157c4349b5e36dee0e0ba3353a63b601dc02bc9a429b4753dd42cc5L115-R122) [[2]](diffhunk://#diff-76c5f5c1d157c4349b5e36dee0e0ba3353a63b601dc02bc9a429b4753dd42cc5L129-R142)
* Added Terraform resources for the NGINX Ingress Controller, including a new IAM policy, role, and Pod Identity association to enable secure LoadBalancer creation.

### EKS Node IAM Policy Updates:
* Introduced a new IAM policy and role policy attachment in `terraform/eks/main.tf` to allow EKS nodes to create and manage LoadBalancers.

### New Variables for Configuration:
* Added variables in `terraform/eks/variables.tf` to enable or configure the NGINX Ingress Controller and External Secrets CSI driver, providing more flexibility for deployment.