### PR TITLE
fix: resolve malformed clickhouse URLs

### DIFF
--- a/charts/helicone-core/templates/jawn/_helpers.tpl
+++ b/charts/helicone-core/templates/jawn/_helpers.tpl
@@ -11,7 +11,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{ define "helicone.jawn.env" -}}
-{{- include "helicone.env.clickhouseHostForJawn" . | nindent 12 }}  # TODO This is tech debt that should be removed
+{{- include "helicone.env.clickhouseHost" . | nindent 12 }}
 {{- include "helicone.env.clickhouseUser" . | nindent 12 }}
 {{- include "helicone.env.clickhousePassword" . | nindent 12 }}
 {{- include "helicone.env.dbHost" . | nindent 12 }}

--- a/charts/helicone-core/templates/web/_helpers.tpl
+++ b/charts/helicone-core/templates/web/_helpers.tpl
@@ -13,8 +13,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 # TODO Break this down further into smaller templates.
 {{- define "helicone.web.env" -}}
 {{ include "helicone.env.clickhouseHost" . }}
-{{ include "helicone.env.clickhouseUrl" . }}
-{{ include "helicone.env.clickhouseHostDocker" . }}
 {{ include "helicone.env.clickhouseUser" . }}
 {{ include "helicone.env.clickhousePassword" . }}
 {{ include "helicone.env.dbHost" . }}

--- a/charts/helicone-core/values.yaml
+++ b/charts/helicone-core/values.yaml
@@ -17,7 +17,7 @@ helicone:
     image:
       repository: helicone/web
       pullPolicy: IfNotPresent
-      tag: "v2025.08.04"
+      tag: "v2025.08.05-2"
     replicaCount: 1
     service:
       annotations: {}
@@ -77,7 +77,7 @@ helicone:
       image:
         repository: helicone/migrations
         pullPolicy: IfNotPresent
-        tag: "v2025.08.04"
+        tag: "v2025.08.05-2"
       resources: {}
 
     cloudSqlProxy:
@@ -213,7 +213,7 @@ helicone:
     image:
       repository: helicone/jawn
       pullPolicy: IfNotPresent
-      tag: "v2025.08.04"
+      tag: "v2025.08.05-2"
     replicaCount: 1
     service:
       annotations: {}


### PR DESCRIPTION
this commit greatly simplifies the clickhouse URLs since standard URLs are required and there is no need to specify different hostnames in different formats