### PR TITLE
fix: add required externalClickhouseHost

### DIFF
--- a/charts/helicone-core/templates/_helpers.tpl
+++ b/charts/helicone-core/templates/_helpers.tpl
@@ -66,12 +66,12 @@ meta.helm.sh/release-namespace: {{ .Release.Namespace }}
 */}}
 
 {{/*
-ClickHouse URL eg http://localhost:18123
+ClickHouse URL with scheme and port eg http://localhost:18123
 */}}
-{{- define "helicone.env.clickhouseHost" -}}
+{{- define "helicone.env.clickhouseUrl" -}}
 - name: CLICKHOUSE_HOST
 {{- if .Values.helicone.clickhouse.enabled }}
-  value: {{ printf "http://%s" (include "clickhouse.name" .) | quote }}
+  value: {{ printf "http://%s:8123" (include "clickhouse.name" .) | quote }}
 {{- else }}
   value: {{ (.Values.helicone.config.externalClickhouseUrl | default .Values.helicone.config.clickhouseHost | required "When clickhouse.enabled is false, either helicone.config.externalClickhouseUrl or helicone.config.clickhouseHost must be provided") | quote }}
 {{- end }}
@@ -85,9 +85,7 @@ ClickHouse hostname for migration scripts (just hostname, no protocol/port, eg `
 {{- if .Values.helicone.clickhouse.enabled }}
   value: {{ include "clickhouse.name" . | quote }}
 {{- else }}
-{{- $url := .Values.helicone.config.externalClickhouseUrl | default .Values.helicone.config.clickhouseHost | required "When clickhouse.enabled is false, either helicone.config.externalClickhouseUrl or helicone.config.clickhouseHost must be provided" }}
-{{- $hostname := $url | replace "https://" "" | replace "http://" "" }}
-  value: {{ $hostname | quote }}
+  value: {{ .Values.helicone.config.externalClickhouseHost | required "When clickhouse.enabled is false, helicone.config.externalClickhouseHost must be provided" }}
 {{- end }}
 {{- end }}
 

--- a/charts/helicone-core/templates/jawn/_helpers.tpl
+++ b/charts/helicone-core/templates/jawn/_helpers.tpl
@@ -11,7 +11,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{ define "helicone.jawn.env" -}}
-{{- include "helicone.env.clickhouseHost" . | nindent 12 }}
+{{- include "helicone.env.clickhouseUrl" . | nindent 12 }}
 {{- include "helicone.env.clickhousePort" . | nindent 12 }}
 {{- include "helicone.env.clickhouseUser" . | nindent 12 }}
 {{- include "helicone.env.clickhousePassword" . | nindent 12 }}

--- a/charts/helicone-core/templates/web/_helpers.tpl
+++ b/charts/helicone-core/templates/web/_helpers.tpl
@@ -12,7 +12,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 # TODO Break this down further into smaller templates.
 {{- define "helicone.web.env" -}}
-{{ include "helicone.env.clickhouseHost" . }}
+{{ include "helicone.env.clickhouseUrl" . }}
 {{ include "helicone.env.clickhousePort" . }}
 {{ include "helicone.env.clickhouseUser" . }}
 {{ include "helicone.env.clickhousePassword" . }}


### PR DESCRIPTION
please ensure `externalClickhouseUrl` follows the URL format, eg `http://localhost:8123`, and `externalClickhouseHost` is just a hostname, eg `localhost`