### PR TITLE
task: single clickhouse url var

### DIFF
--- a/charts/helicone-core/secrets.example.yaml
+++ b/charts/helicone-core/secrets.example.yaml
@@ -19,7 +19,6 @@ helicone:
 
     # External ClickHouse configuration (when clickhouse.enabled=false)
     externalClickhouseUrl: ""
-    externalClickhousePort: ""
     externalClickhouseUsername: ""
     externalClickhousePassword: ""
 

--- a/charts/helicone-core/templates/jawn/_helpers.tpl
+++ b/charts/helicone-core/templates/jawn/_helpers.tpl
@@ -12,7 +12,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{ define "helicone.jawn.env" -}}
 {{- include "helicone.env.clickhouseUrl" . | nindent 12 }}
-{{- include "helicone.env.clickhousePort" . | nindent 12 }}
 {{- include "helicone.env.clickhouseUser" . | nindent 12 }}
 {{- include "helicone.env.clickhousePassword" . | nindent 12 }}
 {{- include "helicone.env.dbHost" . | nindent 12 }}

--- a/charts/helicone-core/templates/jawn/deployment.yaml
+++ b/charts/helicone-core/templates/jawn/deployment.yaml
@@ -20,6 +20,120 @@ spec:
       {{- if and .Values.helicone.s3 .Values.helicone.s3.serviceAccount .Values.helicone.s3.serviceAccount.enabled }}
       serviceAccountName: {{ include "jawn.name" . }}
       {{- end }}
+      initContainers:
+        {{- if .Values.helicone.cloudSqlProxy.enabled }}
+        - name: cloud-sql-proxy
+          image: {{ include "helicone.cloudSqlProxy.image" . }}
+          imagePullPolicy: {{ .Values.helicone.cloudSqlProxy.image.pullPolicy }}
+          args: {{- include "helicone.cloudSqlProxy.args" . | nindent 12 }}
+          ports:
+            - name: sql-proxy
+              containerPort: {{ include "helicone.cloudSqlProxy.port" . }}
+              protocol: TCP
+          {{- if not .Values.helicone.cloudSqlProxy.useWorkloadIdentity }}
+          volumeMounts:
+            - name: cloudsql-key
+              mountPath: /secrets/cloudsql
+              readOnly: true
+          {{- end }}
+          env:
+            - name: CSQL_PROXY_HEALTH_CHECK
+              value: "true"
+            - name: CSQL_PROXY_HTTP_PORT
+              value: "9801"
+            - name: CSQL_PROXY_HTTP_ADDRESS
+              value: 0.0.0.0
+          restartPolicy: Always
+          {{- with .Values.helicone.cloudSqlProxy.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          startupProbe:
+            httpGet:
+              path: /startup
+              port: 9801
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 6
+        {{- end }}
+        - name: wait-for-postgres
+          image: postgres:15-alpine
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for PostgreSQL to be ready..."
+              {{- if .Values.helicone.cloudSqlProxy.enabled }}
+              until pg_isready -h localhost -p {{ include "helicone.cloudSqlProxy.port" . }} -U $(DB_USER); do
+              {{- else }}
+              until pg_isready -h $DB_HOST -p $DB_PORT -U $DB_USER; do
+              {{- end }}
+                echo "PostgreSQL is not ready yet. Waiting..."
+                sleep 2
+              done
+              echo "PostgreSQL is ready!"
+          env:
+            {{- if not .Values.helicone.cloudSqlProxy.enabled }}
+            {{- include "helicone.env.dbHost" . | nindent 12 }}
+            {{- include "helicone.env.dbPort" . | nindent 12 }}
+            {{- end }}
+            {{- include "helicone.env.dbUser" . | nindent 12 }}
+            {{- include "helicone.env.dbPassword" . | nindent 12 }}
+        {{- if .Values.helicone.minio.enabled }}
+        - name: wait-for-minio
+          image: minio/mc:latest
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for MinIO to be ready..."
+              until mc alias set localminio http://{{ include "minio.name" . }}:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD}; do
+                echo "MinIO is not ready yet. Waiting..."
+                sleep 2
+              done
+              echo "MinIO is ready!"
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: helicone-secrets
+                  key: minio-root-user
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: helicone-secrets
+                  key: minio-root-password
+        {{- end }}
+        {{- if .Values.helicone.clickhouse.enabled }}
+        - name: wait-for-clickhouse
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for ClickHouse to be ready..."
+              until curl -sSf {{ .Values.helicone.config.clickhouseUrl }}/ping; do
+                echo "ClickHouse is not ready yet. Waiting..."
+                sleep 2
+              done
+              echo "ClickHouse is ready!"
+        {{- end }}
+        - name: migration-runner
+          image: "{{ .Values.helicone.migrationRunner.image.repository }}:{{ .Values.helicone.migrationRunner.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          {{- with .Values.helicone.migrationRunner.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            {{- include "helicone.env.flywayUrl" . | nindent 12 }}
+            {{- include "helicone.env.flywayUser" . | nindent 12 }}
+            {{- include "helicone.env.flywayPassword" . | nindent 12 }}
+            {{- include "helicone.env.clickhouseUrl" . | nindent 12 }}
+            {{- include "helicone.env.clickhouseUser" . | nindent 12 }}
+            {{- include "helicone.env.clickhousePassword" . | nindent 12 }}
       containers:
         - name: {{ include "jawn.name" $ }}
           image: "{{ .Values.helicone.jawn.image.repository }}:{{ .Values.helicone.jawn.image.tag }}"
@@ -45,5 +159,14 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 10
             failureThreshold: 4
+      {{- if and .Values.helicone.cloudSqlProxy.enabled (not .Values.helicone.cloudSqlProxy.useWorkloadIdentity) }}
+      volumes:
+        - name: cloudsql-key
+          secret:
+            secretName: {{ .Values.helicone.cloudSqlProxy.serviceAccountSecretName }}
+            items:
+              - key: {{ .Values.helicone.cloudSqlProxy.serviceAccountSecretKey }}
+                path: key.json
+      {{- end }}
 
 {{- end }}

--- a/charts/helicone-core/templates/web/_helpers.tpl
+++ b/charts/helicone-core/templates/web/_helpers.tpl
@@ -13,7 +13,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 # TODO Break this down further into smaller templates.
 {{- define "helicone.web.env" -}}
 {{ include "helicone.env.clickhouseUrl" . }}
-{{ include "helicone.env.clickhousePort" . }}
 {{ include "helicone.env.clickhouseUser" . }}
 {{ include "helicone.env.clickhousePassword" . }}
 {{ include "helicone.env.dbHost" . }}

--- a/charts/helicone-core/templates/web/deployment.yaml
+++ b/charts/helicone-core/templates/web/deployment.yaml
@@ -17,20 +17,20 @@ spec:
       labels:
         {{- include "helicone.web.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if or (and .Values.helicone.web.cloudSqlProxy.enabled .Values.helicone.web.cloudSqlProxy.useWorkloadIdentity) (and .Values.helicone.s3 .Values.helicone.s3.serviceAccount .Values.helicone.s3.serviceAccount.enabled) }}
+      {{- if or (and .Values.helicone.cloudSqlProxy.enabled .Values.helicone.cloudSqlProxy.useWorkloadIdentity) (and .Values.helicone.s3 .Values.helicone.s3.serviceAccount .Values.helicone.s3.serviceAccount.enabled) }}
       serviceAccountName: {{ include "web.name" . }}
       {{- end }}
       initContainers:
-        {{- if .Values.helicone.web.cloudSqlProxy.enabled }}
+        {{- if .Values.helicone.cloudSqlProxy.enabled }}
         - name: cloud-sql-proxy
           image: {{ include "helicone.cloudSqlProxy.image" . }}
-          imagePullPolicy: {{ .Values.helicone.web.cloudSqlProxy.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.helicone.cloudSqlProxy.image.pullPolicy }}
           args: {{- include "helicone.cloudSqlProxy.args" . | nindent 12 }}
           ports:
             - name: sql-proxy
               containerPort: {{ include "helicone.cloudSqlProxy.port" . }}
               protocol: TCP
-          {{- if not .Values.helicone.web.cloudSqlProxy.useWorkloadIdentity }}
+          {{- if not .Values.helicone.cloudSqlProxy.useWorkloadIdentity }}
           volumeMounts:
             - name: cloudsql-key
               mountPath: /secrets/cloudsql
@@ -44,7 +44,7 @@ spec:
             - name: CSQL_PROXY_HTTP_ADDRESS
               value: 0.0.0.0
           restartPolicy: Always
-          {{- with .Values.helicone.web.cloudSqlProxy.resources }}
+          {{- with .Values.helicone.cloudSqlProxy.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -58,83 +58,18 @@ spec:
             timeoutSeconds: 2
             failureThreshold: 6
         {{- end }}
-        - name: wait-for-postgres
-          image: postgres:15-alpine
-          command:
-            - sh
-            - -c
-            - |
-              echo "Waiting for PostgreSQL to be ready..."
-              {{- if .Values.helicone.web.cloudSqlProxy.enabled }}
-              until pg_isready -h localhost -p {{ include "helicone.cloudSqlProxy.port" . }} -U $(DB_USER); do
-              {{- else }}
-              until pg_isready -h $(DB_HOST) -p $(DB_PORT) -U $(DB_USER); do
-              {{- end }}
-                echo "PostgreSQL is not ready yet. Waiting..."
-                sleep 2
-              done
-              echo "PostgreSQL is ready!"
-          env:
-            {{- if not .Values.helicone.web.cloudSqlProxy.enabled }}
-            {{- include "helicone.env.dbHost" . | nindent 12 }}
-            {{- include "helicone.env.dbPort" . | nindent 12 }}
-            {{- end }}
-            {{- include "helicone.env.dbUser" . | nindent 12 }}
-            {{- include "helicone.env.dbPassword" . | nindent 12 }}
-        {{- if .Values.helicone.minio.enabled }}
-        - name: wait-for-minio
-          image: minio/mc:latest
-          command:
-            - sh
-            - -c
-            - |
-              echo "Waiting for MinIO to be ready..."
-              until mc alias set localminio http://{{ include "minio.name" . }}:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD}; do
-                echo "MinIO is not ready yet. Waiting..."
-                sleep 2
-              done
-              echo "MinIO is ready!"
-          env:
-            - name: MINIO_ROOT_USER
-              valueFrom:
-                secretKeyRef:
-                  name: helicone-secrets
-                  key: minio-root-user
-            - name: MINIO_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: helicone-secrets
-                  key: minio-root-password
-        {{- end }}
-        {{- if .Values.helicone.clickhouse.enabled }}
-        - name: wait-for-clickhouse
+        - name: wait-for-jawn
           image: curlimages/curl:latest
           command:
             - sh
             - -c
             - |
-              echo "Waiting for ClickHouse to be ready..."
-              until curl -sSf http://{{ include "clickhouse.name" . }}:8123/ping; do
-                echo "ClickHouse is not ready yet. Waiting..."
+              echo "Waiting for Jawn to be ready..."
+              until curl -sSf http://{{ include "jawn.name" . }}:{{ .Values.helicone.jawn.service.port }}/healthcheck; do
+                echo "Jawn is not ready yet. Waiting..."
                 sleep 2
               done
-              echo "ClickHouse is ready!"
-        {{- end }}
-        - name: migration-runner
-          image: "{{ .Values.helicone.web.migrationRunner.image.repository }}:{{ .Values.helicone.web.migrationRunner.image.tag }}"
-          imagePullPolicy: IfNotPresent
-          {{- with .Values.helicone.web.migrationRunner.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          env:
-            {{- include "helicone.env.flywayUrl" . | nindent 12 }}
-            {{- include "helicone.env.flywayUser" . | nindent 12 }}
-            {{- include "helicone.env.flywayPassword" . | nindent 12 }}
-            {{- include "helicone.env.clickhouseHostForMigrations" . | nindent 12 }}
-            {{- include "helicone.env.clickhousePort" . | nindent 12 }}
-            {{- include "helicone.env.clickhouseUser" . | nindent 12 }}
-            {{- include "helicone.env.clickhousePassword" . | nindent 12 }}
+              echo "Jawn is ready!"
       containers:
         - name: web
           image: "{{ .Values.helicone.web.image.repository }}:{{ .Values.helicone.web.image.tag }}"
@@ -166,13 +101,13 @@ spec:
             initialDelaySeconds: 120
             periodSeconds: 10
             failureThreshold: 4
-      {{- if and .Values.helicone.web.cloudSqlProxy.enabled (not .Values.helicone.web.cloudSqlProxy.useWorkloadIdentity) }}
+      {{- if and .Values.helicone.cloudSqlProxy.enabled (not .Values.helicone.cloudSqlProxy.useWorkloadIdentity) }}
       volumes:
         - name: cloudsql-key
           secret:
-            secretName: {{ .Values.helicone.web.cloudSqlProxy.serviceAccountSecretName }}
+            secretName: {{ .Values.helicone.cloudSqlProxy.serviceAccountSecretName }}
             items:
-              - key: {{ .Values.helicone.web.cloudSqlProxy.serviceAccountSecretKey }}
+              - key: {{ .Values.helicone.cloudSqlProxy.serviceAccountSecretKey }}
                 path: key.json
       {{- end }}
 {{- end }}

--- a/charts/helicone-core/templates/web/serviceaccount.yaml
+++ b/charts/helicone-core/templates/web/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if or (and .Values.helicone.web.enabled .Values.helicone.web.cloudSqlProxy.enabled .Values.helicone.web.cloudSqlProxy.useWorkloadIdentity) (and .Values.helicone.s3 .Values.helicone.s3.serviceAccount .Values.helicone.s3.serviceAccount.enabled) }}
+{{- if or (and .Values.helicone.web.enabled .Values.helicone.cloudSqlProxy.enabled .Values.helicone.cloudSqlProxy.useWorkloadIdentity) (and .Values.helicone.s3 .Values.helicone.s3.serviceAccount .Values.helicone.s3.serviceAccount.enabled) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,8 +7,8 @@ metadata:
     {{- include "helicone.labels" . | nindent 4 }}
   annotations:
     {{- include "helicone.annotations" . | nindent 4 }}
-    {{- if and .Values.helicone.web.cloudSqlProxy.enabled .Values.helicone.web.cloudSqlProxy.useWorkloadIdentity .Values.helicone.web.cloudSqlProxy.workloadIdentityAnnotation }}
-    iam.gke.io/gcp-service-account: {{ .Values.helicone.web.cloudSqlProxy.workloadIdentityAnnotation }}
+    {{- if and .Values.helicone.cloudSqlProxy.enabled .Values.helicone.cloudSqlProxy.useWorkloadIdentity .Values.helicone.cloudSqlProxy.workloadIdentityAnnotation }}
+    iam.gke.io/gcp-service-account: {{ .Values.helicone.cloudSqlProxy.workloadIdentityAnnotation }}
     {{- end }}
     {{- if and .Values.helicone.s3 .Values.helicone.s3.serviceAccount .Values.helicone.s3.serviceAccount.enabled }}
     aws.amazon.com/pod-identity: "enabled"

--- a/charts/helicone-core/values.yaml
+++ b/charts/helicone-core/values.yaml
@@ -17,7 +17,7 @@ helicone:
     image:
       repository: helicone/web
       pullPolicy: IfNotPresent
-      tag: "v2025.08.05-2"
+      tag: "v2025.08.06-1"
     replicaCount: 1
     service:
       annotations: {}
@@ -73,39 +73,40 @@ helicone:
           stabilizationWindowSeconds: 60
           percentPolicy: 100
           periodSeconds: 15
-    migrationRunner:
-      image:
-        repository: helicone/migrations
-        pullPolicy: IfNotPresent
-        tag: "v2025.08.05-2"
-      resources: {}
-
-    cloudSqlProxy:
-      enabled: false
-      image:
-        repository: gcr.io/cloudsql-docker/gce-proxy
-        tag: "1.33.2"
-        pullPolicy: IfNotPresent
-      connectionName: ""
-      port: 5432
-      resources:
-        requests:
-          memory: "64Mi"
-          cpu: "50m"
-        limits:
-          memory: "128Mi"
-          cpu: "100m"
-
-      serviceAccountSecretName: "cloudsql-key"
-      serviceAccountSecretKey: "key.json"
-
-      useWorkloadIdentity: false
-      workloadIdentityAnnotation: ""
-
-      extraArgs: []
 
     router:
       enabled: true
+
+  cloudSqlProxy:
+    enabled: false
+    image:
+      repository: gcr.io/cloudsql-docker/gce-proxy
+      tag: "1.33.2"
+      pullPolicy: IfNotPresent
+    connectionName: ""
+    port: 5432
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "50m"
+      limits:
+        memory: "128Mi"
+        cpu: "100m"
+
+    serviceAccountSecretName: "cloudsql-key"
+    serviceAccountSecretKey: "key.json"
+
+    useWorkloadIdentity: false
+    workloadIdentityAnnotation: ""
+
+    extraArgs: []
+
+  migrationRunner:
+    image:
+      repository: helicone/migrations
+      pullPolicy: IfNotPresent
+      tag: "v2025.08.06-1"
+    resources: {}
 
   cloudnativepg:
     enabled: true
@@ -213,7 +214,7 @@ helicone:
     image:
       repository: helicone/jawn
       pullPolicy: IfNotPresent
-      tag: "v2025.08.05-2"
+      tag: "v2025.08.06-1"
     replicaCount: 1
     service:
       annotations: {}
@@ -266,8 +267,7 @@ helicone:
     dbPort: "5432" # Default port for PostgreSQL
     heliconePassword: "changeme-in-production" # Password for helicone app user
     vercelEnv: "development"
-    clickhouseHost: "https://ucewi94kth.us-west-2.aws.clickhouse.cloud" # TODO Not doing DRY between the two configs (above configuration as well)
-    clickhousePort: "8443"
+    clickhouseUrl: "https://ucewi94kth.us-west-2.aws.clickhouse.cloud:8443" # TODO Not doing DRY between the two configs (above configuration as well)
     clickhouseUser: "default"
     s3BucketName: "helm-request-response-storage"
     s3Endpoint: "http://helicone-core-minio:9000"


### PR DESCRIPTION
- use a single clickhouse url to simplify configuration
- move .web.cloudsqlProxy up a level since this is also needed by jawn
- fix dependency startup order by having Jawn depend on clickhouse and pg and migrations, and web depend on jawn