### PR TITLE
Add workload identity to Jawn service account

### DIFF
--- a/charts/helicone-core/templates/jawn/serviceaccount.yaml
+++ b/charts/helicone-core/templates/jawn/serviceaccount.yaml
@@ -7,5 +7,8 @@ metadata:
     {{- include "helicone.labels" . | nindent 4 }}
   annotations:
     {{- include "helicone.annotations" . | nindent 4 }}
+    {{- if and .Values.helicone.cloudSqlProxy.enabled .Values.helicone.cloudSqlProxy.useWorkloadIdentity .Values.helicone.cloudSqlProxy.workloadIdentityAnnotation }}
+    iam.gke.io/gcp-service-account: {{ .Values.helicone.cloudSqlProxy.workloadIdentityAnnotation }}
+    {{- end }}
     aws.amazon.com/pod-identity: "enabled"
-{{- end }} 
+{{- end }}


### PR DESCRIPTION
Needed to allow Jawn to connect to PG via the cloud sql proxy